### PR TITLE
Backend: new fcm contract

### DIFF
--- a/effectiveOfficeBackend/build.gradle.kts
+++ b/effectiveOfficeBackend/build.gradle.kts
@@ -62,10 +62,10 @@ dependencies {
     implementation("io.ktor:ktor-server-swagger:$ktor_version")
     implementation("io.github.smiley4:ktor-swagger-ui:2.2.0")
     implementation("com.google.oauth-client:google-oauth-client-jetty:1.32.1")
-    implementation("com.google.apis:google-api-services-calendar:v3-rev411-1.25.0")
+    implementation("com.google.apis:google-api-services-calendar:v3-rev20220715-2.0.0")
     implementation("com.google.auth:google-auth-library-oauth2-http:1.3.0")
     implementation("com.google.oauth-client:google-oauth-client-jetty:1.34.1")
-    implementation("com.google.firebase:firebase-admin:8.2.0")
+    implementation("com.google.firebase:firebase-admin:9.3.0")
 
     liquibaseRuntime("org.liquibase:liquibase-core:$liquibase_version")
     liquibaseRuntime("org.postgresql:postgresql:$postgresql_driver_version")

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
@@ -68,11 +68,6 @@ class FcmNotificationSender(
             shouldFindIntegrationsAndUtilities = false
         )
         
-        if (bookings.isEmpty()) {
-            logger.info("[sendUpdateContentMessages] Bookings on 1 week from now for {} workspace were empty", workspace.name)
-            return
-        }
-        
         val messageId = UUID.randomUUID().toString()
         val messageBatches = bookings.chunked(MAX_BOOKING_EVENTS_IN_MESSAGE) { bookingList ->
             val fcmWorkspace = fcmWorkspaceConverter

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
@@ -79,7 +79,7 @@ class FcmNotificationSender(
     private fun buildMessagesList(workspace: Workspace, bookings: List<Booking>, topic: String): List<Message> {
         val messageId = UUID.randomUUID().toString()
         if (bookings.isEmpty()) {
-            val message = buildMessage(messageId, workspace, emptyList(), topic, "1", "1")
+            val message = buildMessage(messageId, workspace, bookings, topic, "1", "1")
             return listOf(message)
         }
         
@@ -87,7 +87,7 @@ class FcmNotificationSender(
         val messages = bookingChunks.mapIndexed { index, bookingList ->
             buildMessage(
                 messageId, workspace, bookingList, topic,
-                index.toString(), bookingChunks.size.toString()
+                (index + 1).toString(), bookingChunks.size.toString()
             )
         }
         

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
@@ -64,7 +64,8 @@ class FcmNotificationSender(
         val bookings = bookingService.findAll(
             workspaceId = workspace.id,
             bookingRangeFrom = startTimeMs,
-            bookingRangeTo = endTimeMs
+            bookingRangeTo = endTimeMs,
+            shouldFindIntegrationsAndUtilities = false
         )
         
         if (bookings.isEmpty()) {

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmNotificationSender.kt
@@ -98,7 +98,7 @@ class FcmNotificationSender(
                 )
             }
         }
-        logger.info("[fcmNotificationSender] {} messages have been sent, {} of them successful, {} - failures",
+        logger.info("[handleFcmResponses] {} messages have been sent, {} of them successful, {} - failures",
             batchResponse.responses.size, batchResponse.successCount, batchResponse.failureCount
         )
     }

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmWorkspaceWithBookingsDTOModelConverter.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmWorkspaceWithBookingsDTOModelConverter.kt
@@ -7,7 +7,18 @@ import office.effective.model.Booking
 import office.effective.model.UserModel
 import office.effective.model.Workspace
 
+/**
+ * Converts the [Workspace] and list of its [Booking]
+ * to [FcmWorkspaceWithBookingsDTO]
+ */
 object FcmWorkspaceWithBookingsDTOModelConverter {
+    /**
+     * Converts the [Workspace] and list of its [Booking]
+     * to [FcmWorkspaceWithBookingsDTO]
+     * @param workspace [Workspace] changed workspace
+     * @param bookings booking of workspace
+     * @return @return resulting [FcmWorkspaceWithBookingsDTO] object
+     */
     fun fromModelsToDTO(workspace: Workspace, bookings: List<Booking>): FcmWorkspaceWithBookingsDTO {
         return FcmWorkspaceWithBookingsDTO(
             id = workspace.id.toString(),

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmWorkspaceWithBookingsDTOModelConverter.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmWorkspaceWithBookingsDTOModelConverter.kt
@@ -1,0 +1,34 @@
+package office.effective.common.notifications
+
+import office.effective.dto.fcm.FcmEventDTO
+import office.effective.dto.fcm.FcmOrganizerDTO
+import office.effective.dto.fcm.FcmWorkspaceWithBookingsDTO
+import office.effective.model.Booking
+import office.effective.model.UserModel
+import office.effective.model.Workspace
+
+object FcmWorkspaceWithBookingsDTOModelConverter {
+    fun fromModelsToDTO(workspace: Workspace, bookings: List<Booking>): FcmWorkspaceWithBookingsDTO {
+        return FcmWorkspaceWithBookingsDTO(
+            id = workspace.id.toString(),
+            bookings = bookings.map { booking -> bookingModelToFcmEventDTO(booking) }
+        )
+    }
+    
+    private fun bookingModelToFcmEventDTO(booking: Booking): FcmEventDTO {
+        return FcmEventDTO(
+            id = booking.id,
+            startTime = booking.beginBooking.toEpochMilli(),
+            endTime = booking.endBooking.toEpochMilli(),
+            organizer = booking.owner?.let { userModelToFcmOrganizer(it) }
+        )
+    }
+    
+    private fun userModelToFcmOrganizer(user: UserModel): FcmOrganizerDTO {
+        return FcmOrganizerDTO(
+            id = user.id.toString(),
+            email = user.email,
+            fullName = user.fullName
+        )
+    }
+}

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmWorkspaceWithBookingsDTOModelConverter.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/FcmWorkspaceWithBookingsDTOModelConverter.kt
@@ -11,7 +11,7 @@ import office.effective.model.Workspace
  * Converts the [Workspace] and list of its [Booking]
  * to [FcmWorkspaceWithBookingsDTO]
  */
-object FcmWorkspaceWithBookingsDTOModelConverter {
+class FcmWorkspaceWithBookingsDTOModelConverter {
     /**
      * Converts the [Workspace] and list of its [Booking]
      * to [FcmWorkspaceWithBookingsDTO]

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/INotificationSender.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/INotificationSender.kt
@@ -16,7 +16,13 @@ interface INotificationSender {
      * @author Daniil Zavyalov
      */
     fun sendEmptyMessage(topic: String)
-    
+
+    /**
+     * Sends messages with workspace and bookings in it
+     * for the modified workspace to specified topic
+     * @param topic topic to which the messages will be sent
+     * @param resourceId google calendar's id of workspace
+     */
     fun sendUpdateContentMessages(topic: String, resourceId: String)
 
     /**

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/INotificationSender.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/INotificationSender.kt
@@ -16,6 +16,8 @@ interface INotificationSender {
      * @author Daniil Zavyalov
      */
     fun sendEmptyMessage(topic: String)
+    
+    fun sendUpdateContentMessages(topic: String, resourceId: String)
 
     /**
      * Sends message about workspace modification

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/firebaseDiModule.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/firebaseDiModule.kt
@@ -4,6 +4,8 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.google.firebase.messaging.FirebaseMessaging
+import office.effective.features.calendar.repository.CalendarIdsRepository
+import office.effective.serviceapi.IBookingService
 import org.koin.dsl.module
 import java.io.ByteArrayInputStream
 
@@ -21,6 +23,6 @@ val firebaseDiModule  = module(createdAtStart = true) {
         FirebaseMessaging.getInstance(get<FirebaseApp>())
     }
     single<INotificationSender> {
-        FcmNotificationSender(get<FirebaseMessaging>())
+        FcmNotificationSender(get<FirebaseMessaging>(), get<CalendarIdsRepository>(), get<IBookingService>())
     }
 }

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/firebaseDiModule.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/common/notifications/firebaseDiModule.kt
@@ -22,7 +22,11 @@ val firebaseDiModule  = module(createdAtStart = true) {
     single<FirebaseMessaging> {
         FirebaseMessaging.getInstance(get<FirebaseApp>())
     }
+    single { FcmWorkspaceWithBookingsDTOModelConverter() }
     single<INotificationSender> {
-        FcmNotificationSender(get<FirebaseMessaging>(), get<CalendarIdsRepository>(), get<IBookingService>())
+        FcmNotificationSender(
+            get<FirebaseMessaging>(), get<CalendarIdsRepository>(),
+            get<IBookingService>(), get<FcmWorkspaceWithBookingsDTOModelConverter>()
+        )
     }
 }

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/dto/fcm/FcmEventDTO.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/dto/fcm/FcmEventDTO.kt
@@ -1,0 +1,11 @@
+package office.effective.dto.fcm
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmEventDTO(
+    val id: String?,
+    val startTime: Long,
+    val endTime: Long,
+    val organizer: FcmOrganizerDTO?
+)

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/dto/fcm/FcmOrganizerDTO.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/dto/fcm/FcmOrganizerDTO.kt
@@ -1,0 +1,10 @@
+package office.effective.dto.fcm
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmOrganizerDTO(
+    val id: String,
+    val fullName: String,
+    val email: String
+)

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/dto/fcm/FcmWorkspaceWithBookingsDTO.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/dto/fcm/FcmWorkspaceWithBookingsDTO.kt
@@ -1,0 +1,9 @@
+package office.effective.dto.fcm
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FcmWorkspaceWithBookingsDTO(
+    val id: String,
+    val bookings: List<FcmEventDTO>
+)

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/features/booking/service/BookingService.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/features/booking/service/BookingService.kt
@@ -86,6 +86,8 @@ class BookingService(
      * @param returnInstances return recurring bookings as non-recurrent instances
      * @param bookingRangeTo upper bound (exclusive) for a beginBooking to filter by. Optional.
      * @param bookingRangeFrom lower bound (exclusive) for a endBooking to filter by.
+     * @param shouldFindIntegrationsAndUtilities whether function should find all
+     * workspace utilities and user integrations or not
      * @throws InstanceNotFoundException if [UserModel] or [Workspace] with the given id doesn't exist in database
      * @author Daniil Zavyalov
      */
@@ -94,7 +96,8 @@ class BookingService(
         workspaceId: UUID?,
         returnInstances: Boolean,
         bookingRangeTo: Long?,
-        bookingRangeFrom: Long
+        bookingRangeFrom: Long,
+        shouldFindIntegrationsAndUtilities: Boolean
     ): List<Booking> {
         //TODO move switch-case construction to facade
         val bookingList = when {
@@ -187,7 +190,10 @@ class BookingService(
             }
         }
         if (bookingList.isEmpty()) return bookingList
-        return findIntegrationsAndUtilities(bookingList)
+        if (shouldFindIntegrationsAndUtilities) {
+            return findIntegrationsAndUtilities(bookingList)
+        }
+        return bookingList
     }
 
     /**

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/features/calendar/repository/CalendarIdsRepository.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/features/calendar/repository/CalendarIdsRepository.kt
@@ -1,7 +1,6 @@
 package office.effective.features.calendar.repository
 
 import office.effective.common.exception.InstanceNotFoundException
-import office.effective.config
 import office.effective.features.workspace.converters.WorkspaceRepositoryConverter
 import office.effective.features.workspace.repository.WorkspaceEntity
 import office.effective.features.workspace.repository.WorkspaceRepository
@@ -35,17 +34,22 @@ class CalendarIdsRepository(
 
     /**
      * @param calendarId
+     * @param shouldFindUtilities whether workspace utilities should be found or not
      * @return [Workspace] model by calendar id (String)
      * */
-    fun findWorkspaceById(calendarId: String): Workspace {
+    fun findWorkspaceById(calendarId: String, shouldFindUtilities: Boolean = true): Workspace {
         logger.debug("[findWorkspaceById] retrieving a workspace with calendar id={}", calendarId)
         try {
             val workspaceEntity =
                 db.calendarIds.find { it.calendarId eq calendarId }?.workspace ?: throw InstanceNotFoundException(
                     WorkspaceEntity::class, "Workspace with such google calendar id not found", null
                 )
+            val utilities = if (shouldFindUtilities)
+                workspaceRepository.findUtilitiesByWorkspaceId(workspaceEntity.id)
+            else emptyList()
+            
             return converter.entityToModel(
-                workspaceEntity, workspaceRepository.findUtilitiesByWorkspaceId(workspaceEntity.id)
+                workspaceEntity, utilities
             )
         } catch (ex: InstanceNotFoundException) {
             logger.warn("[findWorkspaceById] can't find a workspace with calendar id ${calendarId}. Creating placeholder.")

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/features/notifications/routes/CalendarNotificationsRouting.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/features/notifications/routes/CalendarNotificationsRouting.kt
@@ -24,7 +24,13 @@ fun Route.calendarNotificationsRouting() {
         post(SwaggerDocument.receiveNotification()) {
             val logger = LoggerFactory.getLogger(FcmNotificationSender::class.java)
             logger.info("[calendarNotificationsRouting] received push notification: {}", call.receive<String>())
-            messageSender.sendEmptyMessage("booking")
+            // Calendar's resource id, https://developers.google.com/calendar/api/guides/push#headers
+            val resourceId = call.request.header("X-Goog-Resource-ID")
+            if (resourceId == null) {
+                logger.warn("[calendarNotificationsRouting] resource id header was null")
+                return@post call.respond(HttpStatusCode.OK)
+            }
+            messageSender.sendUpdateContentMessages("booking", resourceId)
             call.respond(HttpStatusCode.OK)
         }
     }

--- a/effectiveOfficeBackend/src/main/kotlin/office/effective/serviceapi/IBookingService.kt
+++ b/effectiveOfficeBackend/src/main/kotlin/office/effective/serviceapi/IBookingService.kt
@@ -43,6 +43,8 @@ interface IBookingService {
      * @param returnInstances return recurring bookings as non-recurrent instances
      * @param bookingRangeTo upper bound (exclusive) for a beginBooking to filter by. Optional.
      * @param bookingRangeFrom lower bound (exclusive) for a endBooking to filter by.
+     * @param shouldFindIntegrationsAndUtilities whether function should find all
+     * workspace utilities and user integrations or not
      * @throws InstanceNotFoundException if [UserModel] or [Workspace] with the given id doesn't exist in database
      * @author Daniil Zavyalov
      */
@@ -51,7 +53,8 @@ interface IBookingService {
         workspaceId: UUID? = null,
         returnInstances: Boolean = true,
         bookingRangeTo: Long? = null,
-        bookingRangeFrom: Long
+        bookingRangeFrom: Long,
+        shouldFindIntegrationsAndUtilities: Boolean = true
     ): List<Booking>
 
     /**


### PR DESCRIPTION
We receive the google's calendar id from header by which we can find our workspace. Then we will fetch all booking for this workspace for one week from now. We will send the workspace with bookings in batches if there are too many of bookings (see companion object to see how we check if there are too many). These messages will have unique id so that the receiver of these messages could detect if it's continuation or new message.

I'm not sure about converter implementation, so open to suggestions.
I'm also thinking on adding new repository for bookings (specifically for this sender), because the current one's getting more information than we really need (integration, etc). So removing these joins could improve performance of this sender a bit.