### PR TITLE
mobile/EO-788 Fix: Time picker is unresponsive and fails to update on fast scroll

### DIFF
--- a/composeApp/src/commonMain/kotlin/band/effective/office/elevator/components/TimePickerModal.kt
+++ b/composeApp/src/commonMain/kotlin/band/effective/office/elevator/components/TimePickerModal.kt
@@ -14,6 +14,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,7 +40,7 @@ fun TimePickerModal(
     onClickOk: (LocalTime) -> Unit
 ) {
     val selectorSettings = WheelPickerDefaults.selectorProperties(enabled = false)
-    var time = startTime
+    var time by remember { mutableStateOf(startTime) }
 
     Column(
         modifier = modifier

--- a/wheel-picker-compose/src/commonMain/kotlin/com/commandiron/wheel_picker_compose/WheelTimePicker.kt
+++ b/wheel-picker-compose/src/commonMain/kotlin/com/commandiron/wheel_picker_compose/WheelTimePicker.kt
@@ -45,7 +45,6 @@ fun WheelTimePicker(
         selectorProperties,
         onSnappedTime = { snappedTime, _ ->
             onSnappedTime(snappedTime.snappedLocalTime)
-            snappedTime.snappedIndex
         }
     )
 }

--- a/wheel-picker-compose/src/commonMain/kotlin/com/commandiron/wheel_picker_compose/core/WheelTextPicker.kt
+++ b/wheel-picker-compose/src/commonMain/kotlin/com/commandiron/wheel_picker_compose/core/WheelTextPicker.kt
@@ -20,7 +20,7 @@ fun WheelTextPicker(
     style: TextStyle = MaterialTheme.typography.titleMedium,
     color: Color = LocalContentColor.current,
     selectorProperties: SelectorProperties = WheelPickerDefaults.selectorProperties(),
-    onScrollFinished: (snappedIndex: Int) -> Int? = { null },
+    onSnappedIndexChanged: (snappedIndex: Int) -> Unit,
 ) {
     WheelPicker(
         modifier = modifier,
@@ -29,7 +29,7 @@ fun WheelTextPicker(
         count = texts.size,
         rowCount = rowCount,
         selectorProperties = selectorProperties,
-        onScrollFinished = onScrollFinished
+        onSnappedIndexChanged = onSnappedIndexChanged,
     ){ index ->
         Text(
             text = texts[index],


### PR DESCRIPTION
Description:
This pull request addresses a critical bug in the time selection component used for bookings, which was present on both iOS and Android. The picker was unresponsive during fast scrolling, leading to a poor user experience and incorrect booking times.

Issue: When a user tried to select a start or end time for a booking, the time wheel component was laggy. If the user scrolled the wheel quickly, the selected time would often not be registered and would revert to its previous value.

Cause: The component's logic was designed to update the selected time only after the scroll animation had completely finished. It did not track the intermediate values while the wheel was still in motion. During a fast scroll, the animation would end before the component could process and "snap" to the new value, causing the state update to be missed.

Fix:  The core logic of the time picker was changed to ensure it updates its state in real-time. Instead of waiting for the scroll to end, the component now continuously monitors which time value is at the center of the selector.