### PR TITLE
mobile/EO-807 Fix: User profile data remains unchanged after editing

### DIFF
--- a/composeApp/src/commonMain/kotlin/band/effective/office/elevator/ui/profile/mainProfile/MainProfileComponent.kt
+++ b/composeApp/src/commonMain/kotlin/band/effective/office/elevator/ui/profile/mainProfile/MainProfileComponent.kt
@@ -3,6 +3,7 @@ package band.effective.office.elevator.ui.profile.mainProfile
 import band.effective.office.elevator.ui.profile.mainProfile.store.ProfileStore
 import band.effective.office.elevator.ui.profile.mainProfile.store.ProfileStoreFactory
 import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.essenty.lifecycle.doOnStart
 import com.arkivanov.mvikotlin.core.instancekeeper.getStore
 import com.arkivanov.mvikotlin.core.store.StoreFactory
 import com.arkivanov.mvikotlin.extensions.coroutines.labels
@@ -22,6 +23,12 @@ class MainProfileComponent(
         ProfileStoreFactory(
             storeFactory = storeFactory,
         ).create()
+    }
+
+    init {
+        lifecycle.doOnStart {
+            profileStore.accept(ProfileStore.Intent.FetchUserInfo)
+        }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/composeApp/src/commonMain/kotlin/band/effective/office/elevator/ui/profile/mainProfile/store/ProfileStore.kt
+++ b/composeApp/src/commonMain/kotlin/band/effective/office/elevator/ui/profile/mainProfile/store/ProfileStore.kt
@@ -7,6 +7,7 @@ interface ProfileStore : Store<ProfileStore.Intent, ProfileStore.State, ProfileS
 
     sealed interface Intent {
         object SignOutClicked : Intent
+        object FetchUserInfo : Intent
     }
 
     data class State(


### PR DESCRIPTION
Description:
This PR resolves an issue where the user's information on the  profile screen would not update after being modified. The profile data remained stale, forcing the user to restart the app to see their changes.

Cause:
The user information was fetched only once when the ProfileStore was initialized, using a bootstrapper.

Fix:
To solve this, the data-fetching logic has been refactored:
- A new FetchUserInfo intent has been added to the ProfileStore.
- The bootstrapper responsible for the initial data load has been removed.
- Triggering a data refresh is now moved to the UI component, which can call the FetchUserInfo intent whenever the screen becomes active.
