### PR TITLE
mobile/EO-789 Fix: Telegram link transition is not working on iOS

### DIFF
--- a/composeApp/src/iosMain/kotlin/band/effective/office/elevator/expects/PlatformExpects.kt
+++ b/composeApp/src/iosMain/kotlin/band/effective/office/elevator/expects/PlatformExpects.kt
@@ -10,6 +10,8 @@ import platform.UIKit.UIAlertController
 import platform.Foundation.NSURL
 import platform.UIKit.UIApplication
 import platform.Foundation.*
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 actual fun showToast(message: String) {
     Napier.e { message }
@@ -28,11 +30,24 @@ actual fun makeCall(phoneNumber: String) {
 }
 
 actual fun pickTelegram(telegramNick: String) {
-    val urlString = "https://telegram.me/$telegramNick"
-    val url = NSURL.URLWithString(urlString)
-    url?.let{
-        val application = UIApplication.sharedApplication
-        application.openURL(url)
+    if (telegramNick.isBlank()) return
+
+    val appUrl = NSURL(string = "tg://resolve?domain=$telegramNick")
+    val webUrl = NSURL(string = "https://t.me/$telegramNick")
+    val application = UIApplication.sharedApplication
+
+    val urlToOpen = if (application.canOpenURL(appUrl)) {
+        appUrl
+    } else {
+        webUrl
+    }
+
+    dispatch_async(dispatch_get_main_queue()) {
+        application.openURL(
+            url = urlToOpen,
+            options = emptyMap<Any?, Any?>(),
+            completionHandler = null
+        )
     }
 }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -18,6 +18,11 @@
 			</array>
 		</dict>
 	</array>
+	<key>LSApplicationQueriesSchemes</key>
+    <array>
+            <string>tg</string>
+            <string>telegram</string>
+    </array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>New item</key>


### PR DESCRIPTION
Description:
This pull request fixes a bug where the transition to a user's Telegram profile was completely non-functional on iOS. The new implementation ensures a reliable transition by first attempting to open the native app, and falling back to a web browser if the app is not installed.