### PR TITLE
[~]Fix: Update photo upload in SynologyRepositoryImpl and SynologyApi

### DIFF
--- a/mattermost-bot/src/main/java/band/effective/mattermost/models/response/ResponseGetPostsForChannel.kt
+++ b/mattermost-bot/src/main/java/band/effective/mattermost/models/response/ResponseGetPostsForChannel.kt
@@ -7,7 +7,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ResponseGetPostsForChannel(
         @Json(name = "has_next")
-        val hasNext: Boolean,
+        val hasNext: Boolean? = null,
         @Json(name = "next_post_id")
         val nextPostId: String,
         @Json(name = "order")

--- a/mattermost-bot/src/main/java/band/effective/synology/SynologyApi.kt
+++ b/mattermost-bot/src/main/java/band/effective/synology/SynologyApi.kt
@@ -25,7 +25,7 @@ interface SynologyApi {
         @Query("method") method: String,
         @Query("account") login: String,
         @Query("passwd") password: String
-    ): retrofit2.Response<SynologyAuthResponse>
+    ): Response<SynologyAuthResponse>
 
     @GET("/webapi/entry.cgi/SYNO.Foto.Browse.Album?api=SYNO.Foto.Browse.Album")
     suspend fun getAlbums(
@@ -36,14 +36,14 @@ interface SynologyApi {
         @Query("limit") limit: Int
     ): Either<ErrorReason, SynologyAlbumsResponse>
 
-    @POST("/webapi/entry.cgi")
-    @Headers(
-            "X-Requested-With: XMLHttpRequest",
-            "Accept-Encoding: gzip, deflate, br"
-            )
+    @Multipart
+    @POST("/webapi/entry.cgi?api=SYNO.Foto.Upload.Item&method=upload&version=1")
+    @Headers("X-Requested-With: XMLHttpRequest")
     suspend fun uploadPhoto(
-            @Header("Cookie") cookie: String,
-            @Body body: RequestBody
+        @Header("Cookie") cookie: String,
+        @Part file: MultipartBody.Part,
+        @Part("name") name: RequestBody,
+        @Part("duplicate") duplicate: RequestBody
     ): Response<ResponseBody>
 
     @POST("/webapi/entry.cgi")


### PR DESCRIPTION
**Reason**
- Synology API successfully accepted photo uploads, but the response format changed and our code could not deserialize it. As a result, the upload returned an error and no reaction was posted under the Mattermost message.
- The previous implementation incorrectly used @Body with a manually built multipart request. Synology requires a proper multipart/form-data request with parameters passed as parts, not in the body.

**Solution**
- API interface update: Switched uploadPhoto in SynologyApi to a proper @Multipart endpoint (/entry.cgi?api=SYNO.Foto.Upload.Item&method=upload&version=1) 
- Repository refactor:
   1. Removed manual multipart builder and header‑stripping hack.
   2. Added setRequestToUpload(file, fileName, fileType) to prepare the three parts (file, name, duplicate)
   3. Updated uploadPhoto to call the new multipart method, then manually read ResponseBody, and parse JSON with Moshi into UploadPhotoResponse

**Result**
Photos are uploaded to Synology and the JSON response is parsed without errors.
The repository now correctly recognizes a successful upload and triggers the reaction under the Mattermost post.
 

