### PR TITLE
EO-792 Fix: Mattetmost bot - Update photo upload in SynologyRepositoryImpl and SynologyApi

### DIFF
--- a/mattermost-bot/src/main/java/band/effective/mattermost/models/response/ResponseGetPostsForChannel.kt
+++ b/mattermost-bot/src/main/java/band/effective/mattermost/models/response/ResponseGetPostsForChannel.kt
@@ -7,7 +7,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class ResponseGetPostsForChannel(
         @Json(name = "has_next")
-        val hasNext: Boolean,
+        val hasNext: Boolean? = null,
         @Json(name = "next_post_id")
         val nextPostId: String,
         @Json(name = "order")

--- a/mattermost-bot/src/main/java/band/effective/synology/SynologyApi.kt
+++ b/mattermost-bot/src/main/java/band/effective/synology/SynologyApi.kt
@@ -25,7 +25,7 @@ interface SynologyApi {
         @Query("method") method: String,
         @Query("account") login: String,
         @Query("passwd") password: String
-    ): retrofit2.Response<SynologyAuthResponse>
+    ): Response<SynologyAuthResponse>
 
     @GET("/webapi/entry.cgi/SYNO.Foto.Browse.Album?api=SYNO.Foto.Browse.Album")
     suspend fun getAlbums(
@@ -36,14 +36,14 @@ interface SynologyApi {
         @Query("limit") limit: Int
     ): Either<ErrorReason, SynologyAlbumsResponse>
 
-    @POST("/webapi/entry.cgi")
-    @Headers(
-            "X-Requested-With: XMLHttpRequest",
-            "Accept-Encoding: gzip, deflate, br"
-            )
+    @Multipart
+    @POST("/webapi/entry.cgi?api=SYNO.Foto.Upload.Item&method=upload&version=1")
+    @Headers("X-Requested-With: XMLHttpRequest")
     suspend fun uploadPhoto(
-            @Header("Cookie") cookie: String,
-            @Body body: RequestBody
+        @Header("Cookie") cookie: String,
+        @Part file: MultipartBody.Part,
+        @Part("name") name: RequestBody,
+        @Part("duplicate") duplicate: RequestBody
     ): Response<ResponseBody>
 
     @POST("/webapi/entry.cgi")

--- a/mattermost-bot/src/main/java/band/effective/synology/SynologyRepositoryImpl.kt
+++ b/mattermost-bot/src/main/java/band/effective/synology/SynologyRepositoryImpl.kt
@@ -40,10 +40,10 @@ class SynologyRepositoryImpl : SynologyRepository {
     private suspend fun login() {
         println("login in synology")
         val res = synologyApi.auth(
-                version = 3,
-                method = "login",
-                login = getEnv(SynologySettings.synologyAccount),
-                password = getEnv(SynologySettings.synologyPassword),
+            version = 3,
+            method = "login",
+            login = getEnv(SynologySettings.synologyAccount),
+            password = getEnv(SynologySettings.synologyPassword),
         )
         cookie = ""
         val headersCookie = res.headers().toMultimap()["Set-Cookie"]
@@ -51,35 +51,56 @@ class SynologyRepositoryImpl : SynologyRepository {
     }
 
     private suspend fun getAlbums(): Either<ErrorReason, SynologyAlbumsResponse> =
-            synologyApi.getAlbums(
-                    cookie = cookie.orEmpty(),
-                    version = 2,
-                    method = "list",
-                    offset = 0,
-                    limit = 100
-            )
+        synologyApi.getAlbums(
+            cookie = cookie.orEmpty(),
+            version = 2,
+            method = "list",
+            offset = 0,
+            limit = 100
+        )
 
     private suspend fun uploadPhoto(
-            requestBody: RequestBody
+        filePart: MultipartBody.Part,
+        namePart: RequestBody,
+        dupPart: RequestBody
     ): Either<ErrorReason, UploadPhotoResponse> {
-        return synologyApi.uploadPhotoEither(body = requestBody, cookie = cookie.orEmpty())
+        val response = synologyApi.uploadPhoto(
+            cookie = cookie.orEmpty(),
+            file = filePart,
+            name = namePart,
+            duplicate = dupPart
+        )
+        val bodyString = response.body()?.string()
+
+        if (!response.isSuccessful || bodyString == null) {
+            return Either.Failure(ErrorReason.ServerError("HTTP ${response.code()}"))
+        }
+
+        val uploadResponse = try {
+            moshi.adapter(UploadPhotoResponse::class.java).fromJson(bodyString)
+                ?: return Either.Failure(ErrorReason.ServerError("Empty upload response"))
+        } catch (e: Exception) {
+            return Either.Failure(ErrorReason.ServerError("Parsing error: ${e.message}"))
+        }
+
+        return Either.Success(uploadResponse)
     }
 
     private suspend fun addPhotoToAlbums(
-            albumId: Int,
-            itemId: Int
+        albumId: Int,
+        itemId: Int
     ): Either<ErrorReason, AddPhotoToAlbumResponse> {
         val requestBody = RequestBody.create(
-                MediaType.parse("text/plane"),
-                "api=SYNO.Foto.Browse.NormalAlbum&method=add_item&version=1&item=%5B$itemId%5D&id=$albumId"
+            MediaType.parse("text/plane"),
+            "api=SYNO.Foto.Browse.NormalAlbum&method=add_item&version=1&item=%5B$itemId%5D&id=$albumId"
         )
         return synologyApi.addPhotoToAlbum(request = requestBody, cookie = cookie.orEmpty())
     }
 
     override suspend fun uploadPhotoToAlbum(
-            file: ByteArray,
-            fileName: String,
-            fileType: String
+        file: ByteArray,
+        fileName: String,
+        fileType: String
     ): Either<ErrorReason, UploadPhotoResponse> {
         if (cookie == null) login()
 
@@ -105,31 +126,30 @@ class SynologyRepositoryImpl : SynologyRepository {
                 }
             }
         }
-        val requestBody = setRequestToUpload(file, fileName, fileType)
-        return uploadPhoto(requestBody)
+        val (filePart, namePart, dupPart) = setRequestToUpload(file, fileName, fileType)
+        val uploadResult = uploadPhoto(filePart, namePart, dupPart)
+
+        if (uploadResult is Either.Failure) return uploadResult
+
+        val itemId = (uploadResult as? Either.Success)?.data?.uploadedPhoto?.id
+            ?: return Either.Failure(ErrorReason.ServerError("No item id in upload response"))
+
+        val albumId = currentAlbumId ?: return Either.Failure(ErrorReason.ServerError("No album id"))
+
+        val addResult = addPhotoToAlbums(albumId, itemId)
+        if (addResult is Either.Failure) return addResult
+
+        return uploadResult
     }
 
-    private fun setRequestToUpload(file: ByteArray, fileName: String, fileType: String): RequestBody {
-
-        val reqApi = RequestBody.create(MediaType.parse("text/plain"), "SYNO.Foto.Upload.Item")
-        val reqMethod = RequestBody.create(MediaType.parse("text/plain"), "upload")
-        val reqVersion = RequestBody.create(MediaType.parse("text/plain"), "1")
-        val reqDuplicate = RequestBody.create(MediaType.parse("text/plain"), "\"ignore\"")
-        val reqName = RequestBody.create(MediaType.parse("text/plain"), "\"$fileName\"")
-        val reqAlbumId = RequestBody.create(MediaType.parse("text/plain"), (currentAlbumId ?: 0).toString())
-
-        return MultipartBody.Builder().setType(MultipartBody.FORM)
-                .addFormDataPart("api", null, removeHeaderFromRequestBody(reqApi))
-                .addFormDataPart("method", null, removeHeaderFromRequestBody(reqMethod))
-                .addFormDataPart("version", null, removeHeaderFromRequestBody(reqVersion))
-                .addFormDataPart("file", fileName, removeHeaderFromRequestBody(RequestBody.create(
-                        MediaType.get(fileType),
-                        file
-                )))
-                .addFormDataPart("duplicate", null, removeHeaderFromRequestBody(reqDuplicate))
-                .addFormDataPart("name", null, removeHeaderFromRequestBody(reqName))
-                .addFormDataPart("album_id", null, removeHeaderFromRequestBody(reqAlbumId))
-                .build()
+    private fun setRequestToUpload(file: ByteArray, fileName: String, fileType: String): Triple<MultipartBody.Part, RequestBody, RequestBody> {
+        val filePart = MultipartBody.Part.createFormData(
+            "file", fileName,
+            RequestBody.create(MediaType.parse(fileType), file)
+        )
+        val namePart = RequestBody.create(MediaType.parse("text/plain"), "\"$fileName\"")
+        val dupPart = RequestBody.create(MediaType.parse("text/plain"), "\"ignore\"")
+        return Triple(filePart, namePart, dupPart)
     }
 
 


### PR DESCRIPTION
**Reason**

Synology API successfully accepted photo uploads, but the response format changed and our code could not deserialize it. As a result, the upload returned an error and no reaction was posted under the Mattermost message.
The previous implementation incorrectly used @Body with a manually built multipart request. Synology requires a proper multipart/form-data request with parameters passed as parts, not in the body.

**Solution**

API interface update: Switched uploadPhoto in SynologyApi to a proper https://github.com/multipart endpoint (/entry.cgi?api=SYNO.Foto.Upload.Item&method=upload&version=1)

_Repository refactor:_
- Removed manual multipart builder and header‑stripping hack.
- Added setRequestToUpload(file, fileName, fileType) to prepare the three parts (file, name, duplicate)
- Updated uploadPhoto to call the new multipart method, then manually read ResponseBody, and parse JSON with Moshi into UploadPhotoResponse

**Result**
Photos are uploaded to Synology and the JSON response is parsed without errors.
The repository now correctly recognizes a successful upload and triggers the reaction under the Mattermost post.