### PR TITLE
Correct event insertion logic in slot management

### DIFF
--- a/clients/tablet/core/domain/src/commonMain/kotlin/band/effective/office/tablet/core/domain/useCase/SlotUseCase.kt
+++ b/clients/tablet/core/domain/src/commonMain/kotlin/band/effective/office/tablet/core/domain/useCase/SlotUseCase.kt
@@ -22,7 +22,7 @@ class SlotUseCase(
         currentEvent: EventInfo?,
     ): List<Slot> {
         return events
-            .filter { it.startTime >= start && it.startTime <= finish }
+            .filter { it.startTime >= start && it.startTime < finish && it.finishTime <= finish }
             .fold(
                 getEmptyMinSlots(start, finish, minSlotDur)
             ) { acc, eventInfo -> acc.addEvent(eventInfo) }
@@ -61,9 +61,12 @@ class SlotUseCase(
         if (isEmpty()) return listOf(eventInfo.toSlot())
         val list = this.toMutableList()
         list.removeEmptySlot(eventInfo)
-        val predSlot = list.firstOrNull { it.finish > eventInfo.startTime }
-        val predSlotIndex = list.indexOf(predSlot).let { if (it == -1) 0 else it }
-        list.add(predSlotIndex, eventInfo.toSlot())
+        val predSlotIndex = list.indexOfFirst { it.start >= eventInfo.startTime }
+        if (predSlotIndex != -1) {
+            list.add(predSlotIndex, eventInfo.toSlot())
+        } else {
+            list.add(eventInfo.toSlot())
+        }
         return list
     }
 

--- a/clients/tablet/core/ui/src/commonMain/kotlin/band/effective/office/tablet/core/ui/common/EventDurationView.kt
+++ b/clients/tablet/core/ui/src/commonMain/kotlin/band/effective/office/tablet/core/ui/common/EventDurationView.kt
@@ -37,7 +37,8 @@ fun EventDurationView(
     modifier: Modifier = Modifier,
     currentDuration: Int,
     increment: () -> Unit,
-    decrement: () -> Unit
+    decrement: () -> Unit,
+    canIncrementDuration: Boolean = true
 ) {
     Column(modifier = modifier) {
         Text(
@@ -76,6 +77,7 @@ fun EventDurationView(
                 onClick = {
                     increment()
                 },
+                enabled = canIncrementDuration,
                 colors = ButtonDefaults.buttonColors(
                     containerColor = LocalCustomColorsPalette.current.elevationBackground
                 )

--- a/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/BookingEditor.kt
+++ b/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/BookingEditor.kt
@@ -120,7 +120,8 @@ fun BookingEditor(
                         finish = state.event.finishTime.format(timeFormatter),
                         room = component.roomName,
                         isTimeInPastError = state.isTimeInPastError,
-                        isEditable = state.event.isEditable
+                        isEditable = state.event.isEditable,
+                        canIncrementDuration = state.canIncrementDuration
                     )
                 }
             }
@@ -163,7 +164,8 @@ private fun BookingEditor(
     finish: String,
     room: String,
     isTimeInPastError: Boolean,
-    isEditable: Boolean = true
+    isEditable: Boolean = true,
+    canIncrementDuration: Boolean
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     val timeInPastErrorMessage = stringResource(Res.string.is_time_in_past_error)
@@ -205,7 +207,8 @@ private fun BookingEditor(
                 modifier = Modifier.fillMaxWidth().height(100.dp),
                 currentDuration = selectDuration,
                 increment = incrementDuration,
-                decrement = decrementDuration
+                decrement = decrementDuration,
+                canIncrementDuration = canIncrementDuration
             )
             Spacer(modifier = Modifier.height(15.dp))
             EventOrganizerView(

--- a/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/BookingEditorComponent.kt
+++ b/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/BookingEditorComponent.kt
@@ -1,6 +1,7 @@
 package band.effective.office.tablet.feature.bookingEditor.presentation
 
 import band.effective.office.tablet.core.domain.Either
+import band.effective.office.tablet.core.domain.OfficeTime
 import band.effective.office.tablet.core.domain.model.EventInfo
 import band.effective.office.tablet.core.domain.model.Organizer
 import band.effective.office.tablet.core.domain.unbox
@@ -42,7 +43,7 @@ import org.koin.core.component.inject
  * Component responsible for editing booking events.
  * Handles creating new bookings and updating existing ones.
  */
-
+const val DURATION_INCREMENT_MINUTES = 30
 const val DELETE_SUCCESS_DELAY = 2000L
 class BookingEditorComponent(
     componentContext: ComponentContext,
@@ -250,18 +251,26 @@ class BookingEditorComponent(
             )
             val isTimeInPast = newDate <= getCurrentTime()
 
+            val newFinishTime = newDate.asInstant.plus(duration.minutes).asLocalDateTime
+            val finishWorkTime = OfficeTime.finishWorkTime(newDate.date)
+            val isFinishTimeExceeded = newFinishTime > finishWorkTime
+
+            val nextIncrementFinishTime = newDate.asInstant.plus((duration + DURATION_INCREMENT_MINUTES).minutes).asLocalDateTime
+            val canIncrementDuration = nextIncrementFinishTime <= finishWorkTime
+
             updateStateWithNewEventDetails(
                 newDate = newDate,
                 newDuration = duration,
                 newOrganizer = selectOrganizer,
                 busyEvents = busyEvents,
-                isTimeInPast = isTimeInPast
+                isTimeInPast = isTimeInPast,
+                canIncrementDuration = canIncrementDuration
             )
 
             if (selectOrganizer != Organizer.default) {
                 updateButtonState(
                     inputError = isInputError,
-                    busyEvent = busyEvents.isNotEmpty()
+                    busyEvent = busyEvents.isNotEmpty() || isFinishTimeExceeded
                 )
             }
         }
@@ -282,6 +291,14 @@ class BookingEditorComponent(
                 it.fullName == newOrganizer.fullName
             } ?: event.organizer
             val isTimeInPast = newDate <= getCurrentTime()
+
+            val finishWorkTime = OfficeTime.finishWorkTime(newDate.date)
+            val newFinishTime = newDate.asInstant.plus(newDuration.minutes).asLocalDateTime
+            val isFinishTimeExceeded = newFinishTime > finishWorkTime
+
+            val nextIncrementFinishTime = newDate.asInstant.plus((newDuration + DURATION_INCREMENT_MINUTES).minutes).asLocalDateTime
+            val canIncrementDuration = nextIncrementFinishTime <= finishWorkTime
+
             val busyEvents = checkForBusyEvents(
                 date = newDate,
                 duration = newDuration,
@@ -293,12 +310,13 @@ class BookingEditorComponent(
                 newDuration = newDuration,
                 newOrganizer = resolvedOrganizer,
                 busyEvents = busyEvents,
-                isTimeInPast = isTimeInPast
+                isTimeInPast = isTimeInPast,
+                canIncrementDuration = canIncrementDuration
             )
 
             updateButtonState(
                 inputError = !organizers.contains(resolvedOrganizer),
-                busyEvent = busyEvents.isNotEmpty()
+                busyEvent = busyEvents.isNotEmpty() || isFinishTimeExceeded
             )
         }
     }
@@ -353,7 +371,8 @@ class BookingEditorComponent(
         newDuration: Int,
         newOrganizer: Organizer,
         busyEvents: List<EventInfo>,
-        isTimeInPast: Boolean
+        isTimeInPast: Boolean,
+        canIncrementDuration: Boolean
     ) {
         val updatedEvent = createEventInfo(
             id = state.value.event.id,
@@ -369,7 +388,8 @@ class BookingEditorComponent(
                 selectOrganizer = newOrganizer,
                 event = updatedEvent,
                 isBusyEvent = busyEvents.isNotEmpty(),
-                isTimeInPastError = isTimeInPast
+                isTimeInPastError = isTimeInPast,
+                canIncrementDuration = canIncrementDuration
             )
         }
     }

--- a/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/State.kt
+++ b/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/State.kt
@@ -24,7 +24,8 @@ data class State(
     val showSelectDate: Boolean,
     val enableUpdateButton: Boolean,
     val isBusyEvent: Boolean,
-    val isTimeInPastError: Boolean
+    val isTimeInPastError: Boolean,
+    val canIncrementDuration: Boolean
 ) {
     companion object {
         val defaultValue = State(
@@ -46,7 +47,8 @@ data class State(
             showSelectDate = false,
             enableUpdateButton = false,
             isBusyEvent = false,
-            isTimeInPastError = false
+            isTimeInPastError = false,
+            canIncrementDuration = true
         )
     }
 

--- a/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/mapper/EventInfoMapper.kt
+++ b/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/mapper/EventInfoMapper.kt
@@ -1,5 +1,6 @@
 package band.effective.office.tablet.feature.bookingEditor.presentation.mapper
 
+import band.effective.office.tablet.core.domain.OfficeTime
 import band.effective.office.tablet.core.domain.model.EventInfo
 import band.effective.office.tablet.core.domain.model.Slot
 import band.effective.office.tablet.core.domain.util.asInstant
@@ -12,12 +13,15 @@ class EventInfoMapper {
 
     fun mapToUpdateBookingState(eventInfo: EventInfo): State {
         val duration = eventInfo.finishTime.asInstant.minus(eventInfo.startTime.asInstant).inWholeMinutes.toInt()
+        val finishWorkTime = OfficeTime.finishWorkTime(eventInfo.startTime.date)
+        val canIncrementDuration = eventInfo.finishTime < finishWorkTime
         return State.defaultValue.copy(
             date = eventInfo.startTime,
             duration = duration,
             selectOrganizer = eventInfo.organizer,
             inputText = eventInfo.organizer.fullName,
-            event = eventInfo
+            event = eventInfo,
+            canIncrementDuration = canIncrementDuration
         )
     }
 }


### PR DESCRIPTION
Fixed bug where events starting after all slots were incorrectly inserted at index 0 due to finish time check.
Updated logic to check start time, ensuring events are inserted in correct order or appended if latest.

Updated updateEventDetails and updateEventDate to correctly calculate canIncrementDuration based on next increment not exceeding finishWorkTime
Ensured canIncrementDuration is properly set in updateStateWithNewEventDetails to disable the "+" button in EventDurationView
Maintained existing logic for blocking event creation/updating when finish time is exceeded