### PR TITLE
Implement locale-based format for TimePicker

### DIFF
--- a/clients/tablet/core/ui/src/commonMain/kotlin/band/effective/office/tablet/core/ui/utils/DateDisplayMapper.kt
+++ b/clients/tablet/core/ui/src/commonMain/kotlin/band/effective/office/tablet/core/ui/utils/DateDisplayMapper.kt
@@ -59,4 +59,8 @@ object DateDisplayMapper {
         val patterns = getPatternsForLocale()
         return time.toLocalisedString(patterns.time)
     }
+
+    fun is24HourFormat(): Boolean {
+        return getCurrentLanguageCode() != "en"
+    }
 }

--- a/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/datetimepicker/components/TimePickerView.kt
+++ b/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/datetimepicker/components/TimePickerView.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import band.effective.office.tablet.core.ui.theme.LocalCustomColorsPalette
+import band.effective.office.tablet.core.ui.utils.DateDisplayMapper
 import com.mohamedrejeb.calf.ui.timepicker.AdaptiveTimePicker
 import com.mohamedrejeb.calf.ui.timepicker.rememberAdaptiveTimePickerState
 import kotlinx.datetime.LocalDateTime
@@ -19,10 +20,12 @@ fun TimePickerView(
     currentDate: LocalDateTime,
     onSnap: (LocalTime) -> Unit
 ) {
+    val is24Hour = DateDisplayMapper.is24HourFormat()
+
     val state = rememberAdaptiveTimePickerState(
         initialHour = currentDate.hour,
         initialMinute = currentDate.minute,
-        is24Hour = true
+        is24Hour = is24Hour
     )
     LaunchedEffect(state.hour, state.minute) {
         val hour = state.hour


### PR DESCRIPTION
updates the TimePickerView to automatically display time in a 12-hour (for English) or 24-hour format based on the device's locale.