### PR TITLE
fix: Localize remaining dates for EN version

### DIFF
--- a/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/BookingEditor.kt
+++ b/clients/tablet/feature/bookingEditor/src/commonMain/kotlin/band/effective/office/tablet/feature/bookingEditor/presentation/BookingEditor.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,7 +28,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import band.effective.office.tablet.core.domain.model.Organizer
-import band.effective.office.tablet.core.domain.util.timeFormatter
 import band.effective.office.tablet.core.ui.button.SuccessButton
 import band.effective.office.tablet.core.ui.common.AlertButton
 import band.effective.office.tablet.core.ui.common.CrossButtonView
@@ -41,6 +39,7 @@ import band.effective.office.tablet.core.ui.common.SuccessSelectRoomView
 import band.effective.office.tablet.core.ui.date.DateTimeView
 import band.effective.office.tablet.core.ui.theme.h3
 import band.effective.office.tablet.core.ui.theme.h6
+import band.effective.office.tablet.core.ui.utils.DateDisplayMapper
 import band.effective.office.tablet.feature.bookingEditor.Res
 import band.effective.office.tablet.feature.bookingEditor.booking_time_button
 import band.effective.office.tablet.feature.bookingEditor.booking_view_title
@@ -54,7 +53,6 @@ import band.effective.office.tablet.feature.bookingEditor.presentation.datetimep
 import band.effective.office.tablet.feature.bookingEditor.update_button
 import com.arkivanov.decompose.extensions.compose.stack.Children
 import kotlinx.datetime.LocalDateTime
-import kotlinx.datetime.format
 import org.jetbrains.compose.resources.stringResource
 
 @Composable
@@ -116,8 +114,8 @@ fun BookingEditor(
                         enableUpdateButton = state.enableUpdateButton,
                         isNewEvent = !state.isCreatedEvent(),
                         onCreateEvent = { component.sendIntent(Intent.OnBooking) },
-                        start = state.event.startTime.format(timeFormatter),
-                        finish = state.event.finishTime.format(timeFormatter),
+                        start = DateDisplayMapper.formatTime(state.event.startTime),
+                        finish = DateDisplayMapper.formatTime(state.event.finishTime),
                         room = component.roomName,
                         isTimeInPastError = state.isTimeInPastError,
                         isEditable = state.event.isEditable,

--- a/clients/tablet/feature/main/src/commonMain/kotlin/band/effective/office/tablet/feature/main/components/uiComponent/BusyRoomInfoComponent.kt
+++ b/clients/tablet/feature/main/src/commonMain/kotlin/band/effective/office/tablet/feature/main/components/uiComponent/BusyRoomInfoComponent.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -20,11 +19,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
 import band.effective.office.tablet.core.domain.model.EventInfo
-import band.effective.office.tablet.core.domain.util.toFormattedString
 import band.effective.office.tablet.core.ui.theme.LocalCustomColorsPalette
 import band.effective.office.tablet.core.ui.theme.h5
 import band.effective.office.tablet.core.ui.theme.roomInfoColor
 import band.effective.office.tablet.core.ui.theme.undefineStateColor
+import band.effective.office.tablet.core.ui.utils.DateDisplayMapper
 import band.effective.office.tablet.feature.main.Res
 import band.effective.office.tablet.feature.main.room_occupancy_date
 import band.effective.office.tablet.feature.main.room_occupancy_time
@@ -62,7 +61,7 @@ fun BusyRoomInfoComponent(
             isError = isError
         ) {
             Text(
-                text = stringResource(Res.string.room_occupancy_date, event.finishTime.toFormattedString("HH:mm")) +
+                text = stringResource(Res.string.room_occupancy_date, DateDisplayMapper.formatTime(event.finishTime)) +
                         " " + if (timeToFinish > 0) stringResource(Res.string.room_occupancy_time, timeToFinish.getDuration()) else "",
                 style = MaterialTheme.typography.h5,
                 color = roomInfoColor


### PR DESCRIPTION
The following components have been updated to use the centralized `DateDisplayMapper` for correct formatting:
- `BusyRoomInfoComponent`.
- Start and end times on the booking confirmation button in `BookingEditor`.