### PR TITLE
fix: standardize API endpoints path and kiosk mode

### DIFF
--- a/backend/feature/notifications/src/main/kotlin/band/effective/office/backend/feature/notifications/controller/KioskController.kt
+++ b/backend/feature/notifications/src/main/kotlin/band/effective/office/backend/feature/notifications/controller/KioskController.kt
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*
  * REST controller for managing kiosk mode.
  */
 @RestController
-@RequestMapping("/api/v1/kiosk")
+@RequestMapping("/v1/kiosk")
 @Tag(name = "Kiosk", description = "API for managing kiosk mode")
 class KioskController(
     private val notificationSender: INotificationSender,


### PR DESCRIPTION
  - Changed endpoint path from  /api/v1/kiosk  to  /v1/kiosk (removed duplicate  /api  prefix)
